### PR TITLE
Serialization takes ref

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -9,7 +9,7 @@ fn hello_world_write(c: &mut Criterion) {
     c.bench_function("Bench hello world write", |b| {
         b.iter(|| {
             let mut vec = Vec::new();
-            write_compound_tag(&mut vec, hello_world.clone()).expect("Failed to write tag data");
+            write_compound_tag(&mut vec, &hello_world).expect("Failed to write tag data");
         });
     });
 }
@@ -30,7 +30,7 @@ fn servers_list_write(c: &mut Criterion) {
     c.bench_function("Bench servers list write", |b| {
         b.iter(|| {
             let mut vec = Vec::new();
-            write_compound_tag(&mut vec, root_tag.clone()).expect("Failed to write tag data");
+            write_compound_tag(&mut vec, &root_tag).expect("Failed to write tag data");
         });
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! root_tag.insert_compound_tag_vec("servers", servers);
 //!
 //! let mut vec = Vec::new();
-//! write_compound_tag(&mut vec, root_tag).unwrap();
+//! write_compound_tag(&mut vec, &root_tag).unwrap();
 //! ```
 use linked_hash_map::LinkedHashMap;
 use std::fmt::{Debug, Display, Error, Formatter};


### PR DESCRIPTION
Changes`write_compound_tag`, `write_gzip_compound_tag` and `write_zlib_compound_tag` to take a reference instead of ownership.

This is a breaking API change, albeit one very easy to fix.