### PR TITLE
Fix clippy error and warnings

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -83,7 +83,7 @@ pub fn read_zlib_compound_tag<R: Read>(reader: &mut R) -> Result<CompoundTag, Ta
 /// assert_eq!(name, "Minecraft Server");
 /// assert!(hide_address);
 /// ```
-pub fn read_compound_tag<'a, R: Read>(reader: &mut R) -> Result<CompoundTag, TagDecodeError> {
+pub fn read_compound_tag<R: Read>(reader: &mut R) -> Result<CompoundTag, TagDecodeError> {
     let tag_id = reader.read_u8()?;
     let name = read_string(reader)?;
     let tag = read_tag(tag_id, Some(name.as_str()), reader)?;
@@ -103,32 +103,32 @@ fn read_tag<R: Read>(
         1 => {
             let value = reader.read_i8()?;
 
-            return Ok(Tag::Byte(value));
+            Ok(Tag::Byte(value))
         }
         2 => {
             let value = reader.read_i16::<BigEndian>()?;
 
-            return Ok(Tag::Short(value));
+            Ok(Tag::Short(value))
         }
         3 => {
             let value = reader.read_i32::<BigEndian>()?;
 
-            return Ok(Tag::Int(value));
+            Ok(Tag::Int(value))
         }
         4 => {
             let value = reader.read_i64::<BigEndian>()?;
 
-            return Ok(Tag::Long(value));
+            Ok(Tag::Long(value))
         }
         5 => {
             let value = reader.read_f32::<BigEndian>()?;
 
-            return Ok(Tag::Float(value));
+            Ok(Tag::Float(value))
         }
         6 => {
             let value = reader.read_f64::<BigEndian>()?;
 
-            return Ok(Tag::Double(value));
+            Ok(Tag::Double(value))
         }
         7 => {
             let length = reader.read_u32::<BigEndian>()?;
@@ -138,12 +138,12 @@ fn read_tag<R: Read>(
                 value.push(reader.read_i8()?);
             }
 
-            return Ok(Tag::ByteArray(value));
+            Ok(Tag::ByteArray(value))
         }
         8 => {
             let value = read_string(reader)?;
 
-            return Ok(Tag::String(value));
+            Ok(Tag::String(value))
         }
         9 => {
             let list_tags_id = reader.read_u8()?;
@@ -154,7 +154,7 @@ fn read_tag<R: Read>(
                 value.push(read_tag(list_tags_id, None, reader)?);
             }
 
-            return Ok(Tag::List(value));
+            Ok(Tag::List(value))
         }
         10 => {
             let mut tags = LinkedHashMap::new();
@@ -178,7 +178,7 @@ fn read_tag<R: Read>(
                 tags,
             };
 
-            return Ok(Tag::Compound(compound_tag));
+            Ok(Tag::Compound(compound_tag))
         }
         11 => {
             let length = reader.read_u32::<BigEndian>()?;
@@ -188,7 +188,7 @@ fn read_tag<R: Read>(
                 value.push(reader.read_i32::<BigEndian>()?);
             }
 
-            return Ok(Tag::IntArray(value));
+            Ok(Tag::IntArray(value))
         }
         12 => {
             let length = reader.read_u32::<BigEndian>()?;
@@ -198,9 +198,9 @@ fn read_tag<R: Read>(
                 value.push(reader.read_i64::<BigEndian>()?);
             }
 
-            return Ok(Tag::LongArray(value));
+            Ok(Tag::LongArray(value))
         }
-        tag_type_id => return Err(TagDecodeError::UnknownTagType { tag_type_id }),
+        tag_type_id => Err(TagDecodeError::UnknownTagType { tag_type_id }),
     }
 }
 
@@ -245,6 +245,7 @@ fn test_servers_read() {
 }
 
 #[test]
+#[allow(clippy::excessive_precision)]
 fn test_big_test_read() {
     use std::io::Cursor;
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -53,7 +53,7 @@ pub fn write_compound_tag<W: Write>(
 ) -> Result<(), Error> {
     // Tag id
     writer.write_u8(Tag::Compound(CompoundTag::new()).type_id())?;
-    
+
     write_string(writer, compound_tag.name.as_deref().unwrap_or(""))?;
 
     write_inner_compound_tag(writer, compound_tag)
@@ -90,7 +90,7 @@ fn write_tag<W: Write>(writer: &mut W, tag: &Tag) -> Result<(), Error> {
         }
         Tag::String(value) => write_string(writer, value)?,
         Tag::List(value) => {
-            if value.len() > 0 {
+            if !value.is_empty() {
                 writer.write_u8(value[0].type_id())?;
             } else {
                 // Empty list type.
@@ -125,7 +125,7 @@ fn write_tag<W: Write>(writer: &mut W, tag: &Tag) -> Result<(), Error> {
 
 fn write_string<W: Write>(writer: &mut W, value: &str) -> Result<(), Error> {
     writer.write_u16::<BigEndian>(value.len() as u16)?;
-    writer.write(value.as_bytes())?;
+    writer.write_all(value.as_bytes())?;
 
     Ok(())
 }
@@ -152,8 +152,7 @@ fn test_servers_write() {
     server.insert_str("name", "Minecraft Server");
     server.insert_bool("hideAddress", true);
 
-    let mut servers = Vec::new();
-    servers.push(server);
+    let servers = vec![server];
 
     let mut root_tag = CompoundTag::new();
     root_tag.insert_compound_tag_vec("servers", servers);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ impl_from_for_ref!(CompoundTag, Compound);
 impl_from_for_ref!(Vec<i32>, IntArray);
 impl_from_for_ref!(Vec<i64>, LongArray);
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CompoundTag {
     pub name: Option<String>,
     tags: LinkedHashMap<String, Tag>,
@@ -298,10 +298,7 @@ macro_rules! define_list_type (
 
 impl CompoundTag {
     pub fn new() -> Self {
-        CompoundTag {
-            name: None,
-            tags: LinkedHashMap::new(),
-        }
+        CompoundTag::default()
     }
 
     pub fn named(name: impl ToString) -> Self {
@@ -539,7 +536,7 @@ impl<'a> std::iter::FromIterator<(&'a str, Tag)> for CompoundTag {
 
 impl Debug for CompoundTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        let name_ref = self.name.as_ref().map(|x| &**x);
+        let name_ref = self.name.as_deref();
         fmt_tag(f, name_ref, &Tag::Compound(self.clone()), 0)
     }
 }
@@ -577,10 +574,9 @@ fn fmt_tag(
             }
         }
         Tag::Compound(value) => {
-            let name_ref = name.as_ref().map(|x| &**x);
             let length = value.tags.len();
 
-            fmt_list_start(f, type_name, name_ref, length)?;
+            fmt_list_start(f, type_name, name, length)?;
 
             for (name, tag) in &value.tags {
                 fmt_tag(f, Some(name.as_str()), tag, indent + 2)?;


### PR DESCRIPTION
Fixes lints picked up by clippy, one of which is a soundness hole, which I highlighted with a comment. It could lead to writes being only partially applied for some writers.